### PR TITLE
fix: remove hard-coded /mnt/zram target-dir

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,3 @@
-# ZRAM build acceleration
-[build]
-incremental = true
-target-dir = "/mnt/zram/targets/pacha"
-
 [alias]
 t = "test"
 c = "check"


### PR DESCRIPTION
## Summary
- Removes `target-dir = "/mnt/zram/targets/pacha"` from `.cargo/config.toml`
- Removes `incremental = true` (conflicts with CI's `CARGO_INCREMENTAL=0`)
- Fixes lint gate failure: `failed to create directory /mnt/zram/targets — Permission denied`

## Context
The unified CI lint gate runs on the bare host (not in a container). The absolute
path `/mnt/zram` doesn't exist in that context. Standard `target/` dir works everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)